### PR TITLE
Add support for testing auto scale settings

### DIFF
--- a/perfsizesagemaker/load/sagemaker.py
+++ b/perfsizesagemaker/load/sagemaker.py
@@ -45,9 +45,18 @@ class SageMakerLoadManager(LoadManager):
         gatling_run_tag = (
             f"{int(start.timestamp())}-"
             f"{config.parameters[Parameter.instance_type]}-"
-            f"{config.parameters[Parameter.initial_instance_count]}-"
-            f"{scenario_steady_state_tps}TPS"
         )
+        if (
+            Parameter.scaling_enabled in config.parameters
+            and config.parameters[Parameter.scaling_enabled] == "True"
+        ):
+            gatling_run_tag += (
+                f"min{config.parameters[Parameter.scaling_min_instance_count]}-"
+                f"max{config.parameters[Parameter.scaling_max_instance_count]}-"
+            )
+        else:
+            gatling_run_tag += f"{config.parameters[Parameter.initial_instance_count]}-"
+        gatling_run_tag += f"{scenario_steady_state_tps}TPS"
         (
             aws_access_key_id,
             aws_secret_access_key,

--- a/perfsizesagemaker/main.py
+++ b/perfsizesagemaker/main.py
@@ -589,14 +589,16 @@ class Main:
 
         self.recommend_type = self.test_type()
 
-        if self.recommend_type:
+        # Only continue with max count test if type test successful and endurance enabled
+        if self.recommend_type and self.endurance_steady_state_minutes > 0:
             instance_type = self.recommend_type[Parameter.instance_type]
             instance_count_needed = int(self.recommend_type["instance_count_needed"])
             self.recommend_max = self.test_max(
                 instance_type=instance_type, instance_count_needed=instance_count_needed
             )
 
-            if self.recommend_max:
+            # Only continue with min count test if max count test successful and ramp exists
+            if self.recommend_max and self.endurance_ramp_minutes > 0:
                 max_instance_count = int(self.recommend_max["max_instance_count"])
                 invocations_target = int(self.recommend_max["invocations_target"])
                 self.recommend_min = self.test_min(

--- a/perfsizesagemaker/step/sagemaker.py
+++ b/perfsizesagemaker/step/sagemaker.py
@@ -114,3 +114,138 @@ class FirstSuccessStepManager(StepManager):
         config = self.plan.configs[combination]
         self.plan.history.append(config)
         return config
+
+
+# Use binary search to find a suitable scaling_min_instance_count that works,
+# given the traffic ramp from ramp_start_tps to steady_state_tps over
+# ramp_minutes. Set up plan to have scaling_min_instance_count parameter as
+# a list of all possibilities from 1 to scaling_max_instance_count. All other
+# parameters would be fixed to single values. Then the actual test walk can
+# point to the next step config from the list of possibilities.
+class AutoScaleMinFinderStepManager(StepManager):
+    def __init__(self, plan: Plan) -> None:
+        super().__init__(plan)
+        assert len(plan.parameter_lists[Parameter.host]) == 1
+        self.host = plan.parameter_lists[Parameter.host][0]
+
+        assert len(plan.parameter_lists[Parameter.region]) == 1
+        self.region = plan.parameter_lists[Parameter.region][0]
+
+        assert len(plan.parameter_lists[Parameter.endpoint_name]) == 1
+        self.endpoint_name = plan.parameter_lists[Parameter.endpoint_name][0]
+
+        assert len(plan.parameter_lists[Parameter.endpoint_config_name]) == 1
+        self.endpoint_config_name = plan.parameter_lists[
+            Parameter.endpoint_config_name
+        ][0]
+
+        assert len(plan.parameter_lists[Parameter.variant_name]) == 1
+        self.variant_name = plan.parameter_lists[Parameter.variant_name][0]
+
+        assert len(plan.parameter_lists[Parameter.model_name]) == 1
+        self.model_name = plan.parameter_lists[Parameter.model_name][0]
+
+        # Should have already identified a working instance_type at this point.
+        assert len(plan.parameter_lists[Parameter.instance_type]) == 1
+        self.instance_type = plan.parameter_lists[Parameter.instance_type][0]
+
+        # Assert initial_instance_count is not specified. Will force environment
+        # manager to use same value as scaling_min_instance_count for each step.
+        # And specifying full list here would increase combination space.
+        assert Parameter.initial_instance_count not in plan.parameter_lists
+
+        # Assert plan is for auto scale setup.
+        assert len(plan.parameter_lists[Parameter.scaling_enabled]) == 1
+        self.scaling_enabled = plan.parameter_lists[Parameter.scaling_enabled][0]
+        assert self.scaling_enabled == "True"
+
+        # Should have already identified max needed for peak TPS at this point.
+        assert len(plan.parameter_lists[Parameter.scaling_max_instance_count]) == 1
+        self.scaling_max_instance_count = plan.parameter_lists[
+            Parameter.scaling_max_instance_count
+        ][0]
+
+        # Possible scaling_min_instance_count is 1 to scaling_max_instance_count.
+        assert plan.parameter_lists[Parameter.scaling_min_instance_count] == list(
+            map(
+                str,
+                range(1, int(self.scaling_max_instance_count) + 1),
+            )
+        )
+
+        assert len(plan.parameter_lists[Parameter.scaling_metric]) == 1
+        self.scaling_metric = plan.parameter_lists[Parameter.scaling_metric][0]
+
+        assert len(plan.parameter_lists[Parameter.scaling_target]) == 1
+        self.scaling_target = plan.parameter_lists[Parameter.scaling_target][0]
+
+        assert len(plan.parameter_lists[Parameter.ramp_start_tps]) == 1
+        self.ramp_start_tps = plan.parameter_lists[Parameter.ramp_start_tps][0]
+
+        assert len(plan.parameter_lists[Parameter.ramp_minutes]) == 1
+        self.ramp_minutes = plan.parameter_lists[Parameter.ramp_minutes][0]
+
+        assert len(plan.parameter_lists[Parameter.steady_state_tps]) == 1
+        self.steady_state_tps = plan.parameter_lists[Parameter.steady_state_tps][0]
+
+        assert len(plan.parameter_lists[Parameter.steady_state_minutes]) == 1
+        self.steady_state_minutes = plan.parameter_lists[
+            Parameter.steady_state_minutes
+        ][0]
+
+        # Track which scaling_min_instance_count values have been tested so far.
+        self.min_count_upper = int(self.scaling_max_instance_count)
+        self.min_count_lower = 0
+        self.min_count_tested = {self.min_count_lower, self.min_count_upper}
+        self.min_count_current = 0
+
+    def next(self) -> Optional[Config]:
+        # For calculating what minimum instance count to test next, start with
+        # lower bound at 0 and upper bound at max instance count.
+        # Calculate next step at half the distance between them (rounded down).
+        # If step succeeds, set step as new upper bound. Else, set as new lower.
+        # Repeat calculating and testing until next step already tested.
+
+        if not self.plan.history:
+            # No tests run yet, so proceed with initial values.
+            pass
+        else:
+            # Check most recent run, assign new bounds based on result.
+            previous_config = self.plan.history[-1]
+            previous_run = previous_config.runs[-1]
+            if previous_run.status:
+                self.min_count_upper = self.min_count_current
+                self.plan.recommendation = previous_config.parameters
+            else:
+                self.min_count_lower = self.min_count_current
+
+        # Calculate next step
+        self.min_count_current = int((self.min_count_lower + self.min_count_upper) / 2)
+        if self.min_count_current in self.min_count_tested:
+            # Done testing.
+            return None
+
+        # Test next step
+        self.min_count_tested.add(self.min_count_current)
+        combination = (
+            self.host,
+            self.region,
+            self.endpoint_name,
+            self.endpoint_config_name,
+            self.variant_name,
+            self.model_name,
+            self.instance_type,
+            # No initial_instance_count set (default to min_count_current)
+            self.scaling_enabled,
+            str(self.min_count_current),  # scaling_min_instance_count being tested
+            self.scaling_max_instance_count,
+            self.scaling_metric,
+            self.scaling_target,
+            self.ramp_start_tps,
+            self.ramp_minutes,
+            self.steady_state_tps,
+            self.steady_state_minutes,
+        )
+        config = self.plan.configs[combination]
+        self.plan.history.append(config)
+        return config

--- a/resources/docs/auto-scale-metric.md
+++ b/resources/docs/auto-scale-metric.md
@@ -50,9 +50,10 @@ It determines the maximum number of instances needed to support your stated peak
 The report shows the `SageMakerVariantInvocationsPerInstance` as `invocations_target`.
 
 Optionally, if you want to find an auto scale setup, you will need to define what ramp time (in
-minutes) is allowed for traffic to go from 0 TPS to your peak TPS. This process will help you
-determine a suitable minimum number instances needed to support your ramp time. You can follow the
+minutes) is allowed for traffic to go from 0 TPS to your peak TPS. The tool will then test for a
+suitable minimum number of instances needed to support your ramp time.
+
+For more background on the testing logic, or to run additional tests manually, you can follow the
 steps on this page:
 
 - [How to test for auto scaling settings](auto-scale-testing.md)
-

--- a/tests/reporter/test_html.py
+++ b/tests/reporter/test_html.py
@@ -6,856 +6,1379 @@ from perfsize.result.gatling import Metric
 from perfsizesagemaker.constants import Parameter, SageMaker
 from perfsizesagemaker.cost import CostEstimator
 from perfsizesagemaker.reporter.html import HTMLReporter
-from pprint import pformat
-from typing import Dict
+from typing import Dict, List
+import pytest
 
 
-class TestHTMLReporter:
-    def test_render(self) -> None:
+@pytest.fixture
+def peak_tps() -> Decimal:
+    return Decimal(1000)
 
-        # Simulate workflow inputs and results
-        peak_tps = Decimal(10)
-        latency_success_p99_requirements = [
-            Condition(lt(Decimal("400")), "latency_success_p99 < 400"),
-            Condition(gte(Decimal("0")), "latency_success_p99 >= 0"),
-        ]
-        percent_fail_requirements = [
-            Condition(lt(Decimal("0.01")), "percent_fail < 0.01"),
-            Condition(gte(Decimal("0")), "percent_fail >= 0"),
-        ]
-        requirements = {
-            Metric.latency_success_p99: latency_success_p99_requirements,
-            Metric.percent_fail: percent_fail_requirements,
-        }
 
-        inputs: Dict[str, str] = {}
-        inputs[
-            "iam_role_arn"
-        ] = "arn:aws:iam::733536204770:role/machine-learning-platform-prd-jenkins"
-        inputs["host"] = "runtime.sagemaker.us-west-2.amazonaws.com"
-        inputs["region"] = "us-west-2"
-        inputs["endpoint_name"] = "LEARNING-model-sim-public-1"
-        inputs["endpoint_config_name"] = "LEARNING-model-sim-public-1-0"
-        inputs["variant_name"] = "variant-name-1"
-        inputs["model_name"] = "model-sim-public"
-        inputs[
-            "scenario_requests"
-        ] = '[{"path":"bodies/model-sim/1/status-200.input.json","weight":100}]'
-        inputs["peak_tps"] = "10"
-        inputs["latency_success_p99"] = "400"
-        inputs["percent_fail"] = "0.01"
-        inputs[
-            "type_walk"
-        ] = '["ml.m5.large","ml.m5.xlarge","ml.m5.2xlarge","ml.m5.4xlarge"]'
-        inputs["count_walk"] = '["1"]'
-        inputs["tps_walk"] = '["1","10","100"]'
-        inputs["duration_minutes"] = "1"
-        inputs["endurance_ramp_start_tps"] = "0"
-        inputs["endurance_ramp_minutes"] = "0"
-        inputs["endurance_steady_state_minutes"] = "1"
-        inputs["endurance_retries"] = "3"
-        inputs["perfsize_results_dir"] = "perfsize-results-dir"
-        inputs[
-            "job_id_dir"
-        ] = "perfsize-results-dir/job-2021-07-13-0117-model-sim-public"
-        print(f"inputs: {pformat(inputs)}")
+@pytest.fixture
+def latency_success_p99_requirements() -> List[Condition]:
+    return [
+        Condition(lt(Decimal("100")), "latency_success_p99 < 100"),
+        Condition(gte(Decimal("0")), "latency_success_p99 >= 0"),
+    ]
 
-        # Track findings for each testing phase
-        recommend_type: Dict[str, str] = {}
-        recommend_max: Dict[str, str] = {}
-        recommend_min: Dict[str, str] = {}
 
-        # TODO: add region as a parameter... for now, testing with us-west-2
-        cost = CostEstimator("resources/configs/cost/us-west-2.json")
+@pytest.fixture
+def percent_fail_requirements() -> List[Condition]:
+    return [
+        Condition(lt(Decimal("0.01")), "percent_fail < 0.01"),
+        Condition(gte(Decimal("0")), "percent_fail >= 0"),
+    ]
 
-        # Start with test plan to find working instance type.
-        type_plan = Plan(
-            parameter_lists={
-                Parameter.host: ["runtime.sagemaker.us-west-2.amazonaws.com"],
-                Parameter.region: ["us-west-2"],
-                Parameter.endpoint_name: ["LEARNING-model-sim-public-1"],
-                Parameter.endpoint_config_name: ["LEARNING-model-sim-public-1-0"],
-                Parameter.variant_name: ["variant-name-1"],
-                Parameter.model_name: ["model-sim-public"],
-                Parameter.instance_type: [
-                    "ml.m5.large",
-                    "ml.m5.xlarge",
-                    "ml.m5.2xlarge",
-                    "ml.m5.4xlarge",
-                ],
-                Parameter.initial_instance_count: ["1"],
-                Parameter.ramp_start_tps: ["0"],
-                Parameter.ramp_minutes: ["0"],
-                Parameter.steady_state_tps: [
-                    "1",
-                    "10",
-                    "100",
-                ],
-                Parameter.steady_state_minutes: ["1"],
-            },
-            requirements=requirements,
-        )
-        type_plan.configs = {}
-        type_plan.history = []
 
-        # Type config 1 of 6
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.large",
-                "initial_instance_count": "1",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "1",
-                "steady_state_minutes": "1",
-            },
-            requirements=requirements,
-        )
-        config.runs = [
-            Run(
-                id="1622790319-ml.m5.large-1-1TPS",
-                start=datetime.strptime("2021-06-04 07:05:19", "%Y-%m-%d %H:%M:%S"),
-                end=datetime.strptime("2021-06-04 07:06:23", "%Y-%m-%d %H:%M:%S"),
-                results=[
-                    Result(
-                        metric=Metric.count_success, value=Decimal(60), conditions=[]
-                    ),
-                    Result(metric=Metric.count_fail, value=Decimal(0), conditions=[]),
-                    Result(metric=Metric.count_total, value=Decimal(60), conditions=[]),
-                    Result(
-                        metric=Metric.percent_success, value=Decimal(100), conditions=[]
-                    ),
-                    Result(
-                        metric=Metric.percent_fail,
-                        value=Decimal(0),
-                        conditions=percent_fail_requirements,
-                    ),
-                    Result(
-                        metric=Metric.latency_success_min,
-                        value=Decimal(15),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p25,
-                        value=Decimal(24),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p50,
-                        value=Decimal(52),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p75,
-                        value=Decimal(56),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p90,
-                        value=Decimal(65),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p95,
-                        value=Decimal(72),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p98,
-                        value=Decimal(74),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p99,
-                        value=Decimal(100),
-                        conditions=latency_success_p99_requirements,
-                    ),
-                    Result(
-                        metric=Metric.latency_success_max,
-                        value=Decimal(137),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.simulation_start,
-                        value=Decimal(1622790323660),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.simulation_end,
-                        value=Decimal(1622790382662),
-                        conditions=[],
-                    ),
-                ],
-            )
-        ]
-        type_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
+@pytest.fixture
+def requirements(
+    latency_success_p99_requirements: List[Condition],
+    percent_fail_requirements: List[Condition],
+) -> Dict[str, List[Condition]]:
+    return {
+        Metric.latency_success_p99: latency_success_p99_requirements,
+        Metric.percent_fail: percent_fail_requirements,
+    }
+
+
+@pytest.fixture
+def inputs() -> Dict[str, str]:
+    inputs: Dict[str, str] = {}
+    inputs["iam_role_arn"] = "arn:aws:iam::123456789012:role/perfsizesagemaker_role"
+    inputs["host"] = "runtime.sagemaker.us-west-2.amazonaws.com"
+    inputs["region"] = "us-west-2"
+    inputs["endpoint_name"] = "LEARNING-model-simulator-1"
+    inputs["endpoint_config_name"] = "LEARNING-model-simulator-1-0"
+    inputs["variant_name"] = "variant-name-1"
+    inputs["model_name"] = "model-simulator"
+    inputs[
+        "scenario_requests"
+    ] = '[{"path":"bodies/model-sim/1/status-200.input.json","weight":100}]'
+    inputs["peak_tps"] = "1000"
+    inputs["latency_success_p99"] = "100"
+    inputs["percent_fail"] = "0.01"
+    inputs[
+        "type_walk"
+    ] = "['ml.m5.large','ml.m5.xlarge','ml.m5.2xlarge','ml.m5.4xlarge']"
+    inputs["count_walk"] = "[1]"
+    inputs[
+        "tps_walk"
+    ] = "[Decimal('1'),Decimal('10'),Decimal('100'),Decimal('200'),Decimal('300')]"
+    inputs["duration_minutes"] = "5"
+    inputs["endurance_ramp_start_tps"] = "0"
+    inputs["endurance_ramp_minutes"] = "15"
+    inputs["endurance_steady_state_minutes"] = "30"
+    inputs["endurance_retries"] = "3"
+    inputs["perfsize_results_dir"] = "perfsize-results-dir"
+    inputs["job_id_dir"] = "perfsize-results-dir/job-2022-05-01-084016-model-simulator"
+    inputs["cost_file"] = "resources/configs/cost/us-west-2.json"
+    inputs["jar_file"] = "sagemaker-gatling.jar"
+    inputs["logging_config"] = "resources/configs/logging/logging.yml"
+    return inputs
+
+
+@pytest.fixture
+def cost() -> CostEstimator:
+    # TODO: add region as a parameter... for now, testing with us-west-2
+    return CostEstimator("resources/configs/cost/us-west-2.json")
+
+
+@pytest.fixture
+def type_plan(
+    requirements: Dict[str, List[Condition]],
+    percent_fail_requirements: List[Condition],
+    latency_success_p99_requirements: List[Condition],
+) -> Plan:
+    # Start with test plan to find working instance type.
+    type_plan = Plan(
+        parameter_lists={
+            Parameter.host: ["runtime.sagemaker.us-west-2.amazonaws.com"],
+            Parameter.region: ["us-west-2"],
+            Parameter.endpoint_name: ["LEARNING-model-simulator-1"],
+            Parameter.endpoint_config_name: ["LEARNING-model-simulator-1-0"],
+            Parameter.variant_name: ["variant-name-1"],
+            Parameter.model_name: ["model-simulator"],
+            Parameter.instance_type: [
                 "ml.m5.large",
+                "ml.m5.xlarge",
+                "ml.m5.2xlarge",
+                "ml.m5.4xlarge",
+            ],
+            Parameter.initial_instance_count: ["1"],
+            Parameter.ramp_start_tps: ["0"],
+            Parameter.ramp_minutes: ["0"],
+            Parameter.steady_state_tps: [
                 "1",
-                "0",
-                "0",
-                "1",
-                "1",
-            )
-        ] = config
-        type_plan.history.append(config)
-
-        # Type config 2 of 6
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.large",
-                "initial_instance_count": "1",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "10",
-                "steady_state_minutes": "1",
-            },
-            requirements=requirements,
-        )
-        config.runs = [
-            Run(
-                id="1622790384-ml.m5.large-1-10TPS",
-                start=datetime.strptime("2021-06-04 07:06:24", "%Y-%m-%d %H:%M:%S"),
-                end=datetime.strptime("2021-06-04 07:07:28", "%Y-%m-%d %H:%M:%S"),
-                results=[
-                    Result(
-                        metric=Metric.count_success, value=Decimal(600), conditions=[]
-                    ),
-                    Result(metric=Metric.count_fail, value=Decimal(0), conditions=[]),
-                    Result(
-                        metric=Metric.count_total, value=Decimal(600), conditions=[]
-                    ),
-                    Result(
-                        metric=Metric.percent_success, value=Decimal(100), conditions=[]
-                    ),
-                    Result(
-                        metric=Metric.percent_fail,
-                        value=Decimal(0),
-                        conditions=percent_fail_requirements,
-                    ),
-                    Result(
-                        metric=Metric.latency_success_min,
-                        value=Decimal(11),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p25,
-                        value=Decimal(13),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p50,
-                        value=Decimal(14),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p75,
-                        value=Decimal(16),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p90,
-                        value=Decimal(32),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p95,
-                        value=Decimal(50),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p98,
-                        value=Decimal(57),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p99,
-                        value=Decimal(64),
-                        conditions=latency_success_p99_requirements,
-                    ),
-                    Result(
-                        metric=Metric.latency_success_max,
-                        value=Decimal(537),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.simulation_start,
-                        value=Decimal(1622790388054),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.simulation_end,
-                        value=Decimal(1622790447949),
-                        conditions=[],
-                    ),
-                ],
-            )
-        ]
-        type_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
-                "ml.m5.large",
-                "1",
-                "0",
-                "0",
                 "10",
-                "1",
-            )
-        ] = config
-        type_plan.history.append(config)
-
-        # Type config 3 of 6
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.large",
-                "initial_instance_count": "1",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "100",
-                "steady_state_minutes": "1",
-            },
-            requirements=requirements,
-        )
-        config.runs = [
-            Run(
-                id="1622790449-ml.m5.large-1-100TPS",
-                start=datetime.strptime("2021-06-04 07:07:29", "%Y-%m-%d %H:%M:%S"),
-                end=datetime.strptime("2021-06-04 07:08:35", "%Y-%m-%d %H:%M:%S"),
-                results=[
-                    Result(
-                        metric=Metric.count_success, value=Decimal(6000), conditions=[]
-                    ),
-                    Result(metric=Metric.count_fail, value=Decimal(0), conditions=[]),
-                    Result(
-                        metric=Metric.count_total, value=Decimal(6000), conditions=[]
-                    ),
-                    Result(
-                        metric=Metric.percent_success, value=Decimal(100), conditions=[]
-                    ),
-                    Result(
-                        metric=Metric.percent_fail,
-                        value=Decimal(0),
-                        conditions=percent_fail_requirements,
-                    ),
-                    Result(
-                        metric=Metric.latency_success_min,
-                        value=Decimal(8),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p25,
-                        value=Decimal(10),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p50,
-                        value=Decimal(11),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p75,
-                        value=Decimal(11),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p90,
-                        value=Decimal(13),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p95,
-                        value=Decimal(14),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p98,
-                        value=Decimal(22),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p99,
-                        value=Decimal(25),
-                        conditions=latency_success_p99_requirements,
-                    ),
-                    Result(
-                        metric=Metric.latency_success_max,
-                        value=Decimal(1026),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.simulation_start,
-                        value=Decimal(1622790453538),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.simulation_end,
-                        value=Decimal(1622790514030),
-                        conditions=[],
-                    ),
-                ],
-            )
-        ]
-        type_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
-                "ml.m5.large",
-                "1",
-                "0",
-                "0",
                 "100",
-                "1",
-            )
-        ] = config
-        type_plan.history.append(config)
+                "200",
+                "300",
+            ],
+            Parameter.steady_state_minutes: ["5"],
+        },
+        requirements=requirements,
+    )
+    type_plan.configs = {}
+    type_plan.history = []
 
-        # Type config 4 of 6 - did not run
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.xlarge",
-                "initial_instance_count": "1",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "1",
-                "steady_state_minutes": "1",
-            },
-            requirements=requirements,
-        )
-        config.runs = []
-        type_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
-                "ml.m5.xlarge",
-                "1",
-                "0",
-                "0",
-                "1",
-                "1",
-            )
-        ] = config
-
-        # Type config 5 of 6 - did not run
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.xlarge",
-                "initial_instance_count": "1",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "10",
-                "steady_state_minutes": "1",
-            },
-            requirements=requirements,
-        )
-        config.runs = []
-        type_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
-                "ml.m5.xlarge",
-                "1",
-                "0",
-                "0",
-                "10",
-                "1",
-            )
-        ] = config
-
-        # Type config 6 of 6 - did not run
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.xlarge",
-                "initial_instance_count": "1",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "100",
-                "steady_state_minutes": "1",
-            },
-            requirements=requirements,
-        )
-        config.runs = []
-        type_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
-                "ml.m5.xlarge",
-                "1",
-                "0",
-                "0",
-                "100",
-                "1",
-            )
-        ] = config
-
-        type_plan.recommendation = {
+    # Type config 1 of 5 (omitting other combos to 20)
+    config = Config(
+        parameters={
             "host": "runtime.sagemaker.us-west-2.amazonaws.com",
             "region": "us-west-2",
-            "endpoint_name": "LEARNING-model-sim-public-1",
-            "endpoint_config_name": "LEARNING-model-sim-public-1-0",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
             "variant_name": "variant-name-1",
-            "model_name": "model-sim-public",
+            "model_name": "model-simulator",
+            "instance_type": "ml.m5.large",
+            "initial_instance_count": "1",
+            "ramp_start_tps": "0",
+            "ramp_minutes": "0",
+            "steady_state_tps": "1",
+            "steady_state_minutes": "5",
+        },
+        requirements=requirements,
+    )
+    config.runs = [
+        Run(
+            id="1651394546-ml.m5.large-1-1TPS",
+            start=datetime.strptime("2022-05-01 08:42:30", "%Y-%m-%d %H:%M:%S"),
+            end=datetime.strptime("2022-05-01 08:47:30", "%Y-%m-%d %H:%M:%S"),
+            results=[
+                Result(metric=Metric.count_success, value=Decimal(300), conditions=[]),
+                Result(metric=Metric.count_fail, value=Decimal(0), conditions=[]),
+                Result(metric=Metric.count_total, value=Decimal(300), conditions=[]),
+                Result(
+                    metric=Metric.percent_success, value=Decimal(100), conditions=[]
+                ),
+                Result(
+                    metric=Metric.percent_fail,
+                    value=Decimal(0),
+                    conditions=percent_fail_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_min,
+                    value=Decimal(15),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p25,
+                    value=Decimal(24),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p50,
+                    value=Decimal(52),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p75,
+                    value=Decimal(56),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p90,
+                    value=Decimal(65),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p95,
+                    value=Decimal(72),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p98,
+                    value=Decimal(74),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p99,
+                    value=Decimal(99),
+                    conditions=latency_success_p99_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_max,
+                    value=Decimal(137),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_start,
+                    value=Decimal(1651394550257),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_end,
+                    value=Decimal(1651394850240),
+                    conditions=[],
+                ),
+            ],
+        )
+    ]
+    type_plan.configs[
+        (
+            "runtime.sagemaker.us-west-2.amazonaws.com",
+            "us-west-2",
+            "LEARNING-model-simulator-1",
+            "LEARNING-model-simulator-1-0",
+            "variant-name-1",
+            "model-simulator",
+            "ml.m5.large",
+            "1",
+            "0",
+            "0",
+            "1",
+            "5",
+        )
+    ] = config
+    type_plan.history.append(config)
+
+    # Type config 2 of 5 (omitting other combos to 20)
+    config = Config(
+        parameters={
+            "host": "runtime.sagemaker.us-west-2.amazonaws.com",
+            "region": "us-west-2",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
+            "variant_name": "variant-name-1",
+            "model_name": "model-simulator",
+            "instance_type": "ml.m5.large",
+            "initial_instance_count": "1",
+            "ramp_start_tps": "0",
+            "ramp_minutes": "0",
+            "steady_state_tps": "10",
+            "steady_state_minutes": "5",
+        },
+        requirements=requirements,
+    )
+    config.runs = [
+        Run(
+            id="1651394853-ml.m5.large-1-10TPS",
+            start=datetime.strptime("2022-05-01 08:47:37", "%Y-%m-%d %H:%M:%S"),
+            end=datetime.strptime("2022-05-01 08:52:37", "%Y-%m-%d %H:%M:%S"),
+            results=[
+                Result(metric=Metric.count_success, value=Decimal(3000), conditions=[]),
+                Result(metric=Metric.count_fail, value=Decimal(0), conditions=[]),
+                Result(metric=Metric.count_total, value=Decimal(3000), conditions=[]),
+                Result(
+                    metric=Metric.percent_success, value=Decimal(100), conditions=[]
+                ),
+                Result(
+                    metric=Metric.percent_fail,
+                    value=Decimal(0),
+                    conditions=percent_fail_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_min,
+                    value=Decimal(11),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p25,
+                    value=Decimal(13),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p50,
+                    value=Decimal(14),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p75,
+                    value=Decimal(16),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p90,
+                    value=Decimal(32),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p95,
+                    value=Decimal(50),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p98,
+                    value=Decimal(57),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p99,
+                    value=Decimal(64),
+                    conditions=latency_success_p99_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_max,
+                    value=Decimal(537),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_start,
+                    value=Decimal(1651394857606),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_end,
+                    value=Decimal(1651395157675),
+                    conditions=[],
+                ),
+            ],
+        )
+    ]
+    type_plan.configs[
+        (
+            "runtime.sagemaker.us-west-2.amazonaws.com",
+            "us-west-2",
+            "LEARNING-model-simulator-1",
+            "LEARNING-model-simulator-1-0",
+            "variant-name-1",
+            "model-simulator",
+            "ml.m5.large",
+            "1",
+            "0",
+            "0",
+            "10",
+            "5",
+        )
+    ] = config
+    type_plan.history.append(config)
+
+    # Type config 3 of 5 (omitting other combos to 20)
+    config = Config(
+        parameters={
+            "host": "runtime.sagemaker.us-west-2.amazonaws.com",
+            "region": "us-west-2",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
+            "variant_name": "variant-name-1",
+            "model_name": "model-simulator",
             "instance_type": "ml.m5.large",
             "initial_instance_count": "1",
             "ramp_start_tps": "0",
             "ramp_minutes": "0",
             "steady_state_tps": "100",
-            "steady_state_minutes": "1",
-        }
-
-        # Next is test plan to find max instance count needed for peak TPS.
-        instance_type = type_plan.recommendation[Parameter.instance_type]
-        initial_instance_count = Decimal(
-            type_plan.recommendation[Parameter.initial_instance_count]
+            "steady_state_minutes": "5",
+        },
+        requirements=requirements,
+    )
+    config.runs = [
+        Run(
+            id="1651395164-ml.m5.large-1-100TPS",
+            start=datetime.strptime("2022-05-01 08:52:44", "%Y-%m-%d %H:%M:%S"),
+            end=datetime.strptime("2022-05-01 08:57:44", "%Y-%m-%d %H:%M:%S"),
+            results=[
+                Result(
+                    metric=Metric.count_success, value=Decimal(29998), conditions=[]
+                ),
+                Result(metric=Metric.count_fail, value=Decimal(2), conditions=[]),
+                Result(metric=Metric.count_total, value=Decimal(30000), conditions=[]),
+                Result(
+                    metric=Metric.percent_success,
+                    value=Decimal("99.99333333333333333333333333"),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.percent_fail,
+                    value=Decimal("0.006666666666666666666666666667"),
+                    conditions=percent_fail_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_min,
+                    value=Decimal(7),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p25,
+                    value=Decimal(9),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p50,
+                    value=Decimal(10),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p75,
+                    value=Decimal(11),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p90,
+                    value=Decimal(12),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p95,
+                    value=Decimal(13),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p98,
+                    value=Decimal(19),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p99,
+                    value=Decimal(26),
+                    conditions=latency_success_p99_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_max,
+                    value=Decimal(1476),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_start,
+                    value=Decimal(1651395164000),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_end,
+                    value=Decimal(1651395464000),
+                    conditions=[],
+                ),
+            ],
         )
-        steady_state_tps = Decimal(type_plan.recommendation[Parameter.steady_state_tps])
-        tps_per_instance = steady_state_tps / initial_instance_count
-        recommend_type[Parameter.instance_type] = instance_type
-        recommend_type[Parameter.initial_instance_count] = f"{initial_instance_count}"
-        recommend_type[Parameter.steady_state_tps] = f"{steady_state_tps}"
-        recommend_type["tps_per_instance"] = f"{tps_per_instance}"
-        instance_count_needed = math.ceil(peak_tps / tps_per_instance)
-        recommend_type["estimate"] = (
-            f"Last green run was {steady_state_tps} TPS supported by {initial_instance_count} instances of {instance_type}.\n"
-            f"{steady_state_tps} / {initial_instance_count} = {tps_per_instance} TPS per instance.\n"
-            f"To support {peak_tps} TPS, we need ceiling({peak_tps} / {tps_per_instance}) = {instance_count_needed} instances."
+    ]
+    type_plan.configs[
+        (
+            "runtime.sagemaker.us-west-2.amazonaws.com",
+            "us-west-2",
+            "LEARNING-model-simulator-1",
+            "LEARNING-model-simulator-1-0",
+            "variant-name-1",
+            "model-simulator",
+            "ml.m5.large",
+            "1",
+            "0",
+            "0",
+            "100",
+            "5",
         )
+    ] = config
+    type_plan.history.append(config)
 
-        max_count_plan = Plan(
-            parameter_lists={
-                Parameter.host: ["runtime.sagemaker.us-west-2.amazonaws.com"],
-                Parameter.region: ["us-west-2"],
-                Parameter.endpoint_name: ["LEARNING-model-sim-public-1"],
-                Parameter.endpoint_config_name: ["LEARNING-model-sim-public-1-0"],
-                Parameter.variant_name: ["variant-name-1"],
-                Parameter.model_name: ["model-sim-public"],
-                Parameter.instance_type: ["ml.m5.large"],
-                Parameter.initial_instance_count: ["2", "3", "4", "5"],
-                Parameter.ramp_start_tps: ["0"],
-                Parameter.ramp_minutes: ["0"],
-                Parameter.steady_state_tps: [f"{peak_tps}"],
-                Parameter.steady_state_minutes: ["30"],
-            },
-            requirements=requirements,
+    # Type config 4 of 5 (omitting other combos to 20)
+    config = Config(
+        parameters={
+            "host": "runtime.sagemaker.us-west-2.amazonaws.com",
+            "region": "us-west-2",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
+            "variant_name": "variant-name-1",
+            "model_name": "model-simulator",
+            "instance_type": "ml.m5.large",
+            "initial_instance_count": "1",
+            "ramp_start_tps": "0",
+            "ramp_minutes": "0",
+            "steady_state_tps": "200",
+            "steady_state_minutes": "5",
+        },
+        requirements=requirements,
+    )
+    config.runs = [
+        Run(
+            id="1651395471-ml.m5.large-1-200TPS",
+            start=datetime.strptime("2022-05-01 08:57:51", "%Y-%m-%d %H:%M:%S"),
+            end=datetime.strptime("2022-05-01 09:02:51", "%Y-%m-%d %H:%M:%S"),
+            results=[
+                Result(
+                    metric=Metric.count_success, value=Decimal(59984), conditions=[]
+                ),
+                Result(metric=Metric.count_fail, value=Decimal(16), conditions=[]),
+                Result(metric=Metric.count_total, value=Decimal(60000), conditions=[]),
+                Result(
+                    metric=Metric.percent_success,
+                    value=Decimal("99.97333333333333333333333333"),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.percent_fail,
+                    value=Decimal("0.02666666666666666666666666667"),
+                    conditions=percent_fail_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_min,
+                    value=Decimal(7),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p25,
+                    value=Decimal(9),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p50,
+                    value=Decimal(10),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p75,
+                    value=Decimal(11),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p90,
+                    value=Decimal(12),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p95,
+                    value=Decimal(12),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p98,
+                    value=Decimal(18),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p99,
+                    value=Decimal(22),
+                    conditions=latency_success_p99_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_max,
+                    value=Decimal(1882),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_start,
+                    value=Decimal(1651395471000),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_end,
+                    value=Decimal(1651395771000),
+                    conditions=[],
+                ),
+            ],
         )
-        max_count_plan.configs = {}
-        max_count_plan.history = []
-
-        # Max count config 1 of 4
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.large",
-                "initial_instance_count": "2",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "10",
-                "steady_state_minutes": "30",
-            },
-            requirements=requirements,
+    ]
+    type_plan.configs[
+        (
+            "runtime.sagemaker.us-west-2.amazonaws.com",
+            "us-west-2",
+            "LEARNING-model-simulator-1",
+            "LEARNING-model-simulator-1-0",
+            "variant-name-1",
+            "model-simulator",
+            "ml.m5.large",
+            "1",
+            "0",
+            "0",
+            "200",
+            "5",
         )
-        config.runs = [
-            Run(
-                id="1622790540-ml.m5.large-2-10TPS",
-                start=datetime.strptime("2021-06-04 07:09:00", "%Y-%m-%d %H:%M:%S"),
-                end=datetime.strptime("2021-06-04 07:39:00", "%Y-%m-%d %H:%M:%S"),
-                results=[
-                    Result(
-                        metric=Metric.count_success, value=Decimal(18000), conditions=[]
-                    ),
-                    Result(metric=Metric.count_fail, value=Decimal(0), conditions=[]),
-                    Result(
-                        metric=Metric.count_total, value=Decimal(18000), conditions=[]
-                    ),
-                    Result(
-                        metric=Metric.percent_success, value=Decimal(100), conditions=[]
-                    ),
-                    Result(
-                        metric=Metric.percent_fail,
-                        value=Decimal(0),
-                        conditions=percent_fail_requirements,
-                    ),
-                    Result(
-                        metric=Metric.latency_success_min,
-                        value=Decimal(16),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p25,
-                        value=Decimal(25),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p50,
-                        value=Decimal(53),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p75,
-                        value=Decimal(57),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p90,
-                        value=Decimal(66),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p95,
-                        value=Decimal(73),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p98,
-                        value=Decimal(75),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.latency_success_p99,
-                        value=Decimal(101),
-                        conditions=latency_success_p99_requirements,
-                    ),
-                    Result(
-                        metric=Metric.latency_success_max,
-                        value=Decimal(138),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.simulation_start,
-                        value=Decimal(1622790540000),
-                        conditions=[],
-                    ),
-                    Result(
-                        metric=Metric.simulation_end,
-                        value=Decimal(1622792340000),
-                        conditions=[],
-                    ),
-                ],
-            )
-        ]
-        max_count_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
-                "ml.m5.large",
-                "2",
-                "0",
-                "0",
-                "10",
-                "30",
-            )
-        ] = config
-        max_count_plan.history.append(config)
+    ] = config
+    type_plan.history.append(config)
 
-        # Max count config 2 of 4
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.large",
-                "initial_instance_count": "3",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "10",
-                "steady_state_minutes": "30",
-            },
-            requirements=requirements,
+    # Type config 5 of 5 - did not run (omitting other combos to 20)
+    config = Config(
+        parameters={
+            "host": "runtime.sagemaker.us-west-2.amazonaws.com",
+            "region": "us-west-2",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
+            "variant_name": "variant-name-1",
+            "model_name": "model-simulator",
+            "instance_type": "ml.m5.large",
+            "initial_instance_count": "1",
+            "ramp_start_tps": "0",
+            "ramp_minutes": "0",
+            "steady_state_tps": "300",
+            "steady_state_minutes": "5",
+        },
+        requirements=requirements,
+    )
+    config.runs = []
+    type_plan.configs[
+        (
+            "runtime.sagemaker.us-west-2.amazonaws.com",
+            "us-west-2",
+            "LEARNING-model-simulator-1",
+            "LEARNING-model-simulator-1-0",
+            "variant-name-1",
+            "model-simulator",
+            "ml.m5.large",
+            "1",
+            "0",
+            "0",
+            "300",
+            "5",
         )
-        config.runs = []
-        max_count_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
-                "ml.m5.large",
-                "3",
-                "0",
-                "0",
-                "10",
-                "30",
-            )
-        ] = config
+    ] = config
 
-        # Max count config 3 of 4
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.large",
-                "initial_instance_count": "4",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "10",
-                "steady_state_minutes": "30",
-            },
-            requirements=requirements,
+    # Omitting type config 6 through 20 for brevity (all were not run):
+    # ml.m5.xlarge: 1, 10, 100, 200, 300 TPS
+    # ml.m5.2xlarge: 1, 10, 100, 200, 300 TPS
+    # ml.m5.4xlarge: 1, 10, 100, 200, 300 TPS
+
+    type_plan.recommendation = {
+        Parameter.host: "runtime.sagemaker.us-west-2.amazonaws.com",
+        Parameter.region: "us-west-2",
+        Parameter.endpoint_name: "LEARNING-model-simulator-1",
+        Parameter.endpoint_config_name: "LEARNING-model-simulator-1-0",
+        Parameter.variant_name: "variant-name-1",
+        Parameter.model_name: "model-simulator",
+        Parameter.instance_type: "ml.m5.large",
+        Parameter.initial_instance_count: "1",
+        Parameter.ramp_start_tps: "0",
+        Parameter.ramp_minutes: "0",
+        Parameter.steady_state_tps: "100",
+        Parameter.steady_state_minutes: "5",
+    }
+    return type_plan
+
+
+@pytest.fixture
+def instance_type(type_plan: Plan) -> str:
+    return type_plan.recommendation[Parameter.instance_type]
+
+
+@pytest.fixture
+def recommend_type(
+    type_plan: Plan, peak_tps: Decimal, instance_type: str
+) -> Dict[str, str]:
+    recommend_type: Dict[str, str] = {}
+    initial_instance_count = Decimal(
+        type_plan.recommendation[Parameter.initial_instance_count]
+    )
+    steady_state_tps = Decimal(type_plan.recommendation[Parameter.steady_state_tps])
+    tps_per_instance = steady_state_tps / initial_instance_count
+    recommend_type[Parameter.instance_type] = instance_type
+    recommend_type[Parameter.initial_instance_count] = f"{initial_instance_count}"
+    recommend_type[Parameter.steady_state_tps] = f"{steady_state_tps}"
+    recommend_type["tps_per_instance"] = f"{tps_per_instance}"
+    instance_count_needed = math.ceil(peak_tps / tps_per_instance)
+    recommend_type["instance_count_needed"] = f"{instance_count_needed}"
+    recommend_type["explanation"] = (
+        f"Last green run was {steady_state_tps} TPS supported by {initial_instance_count} instances of {instance_type}.\n"
+        f"{steady_state_tps} / {initial_instance_count} = {tps_per_instance} TPS per instance.\n"
+        f"To support {peak_tps} TPS, we need ceiling({peak_tps} / {tps_per_instance}) = {instance_count_needed} instances."
+    )
+    return recommend_type
+
+
+@pytest.fixture
+def max_count_plan(
+    peak_tps: Decimal,
+    requirements: Dict[str, List[Condition]],
+    percent_fail_requirements: List[Condition],
+    latency_success_p99_requirements: List[Condition],
+) -> Plan:
+    # Next is test plan to find max instance count needed for peak TPS.
+    max_count_plan = Plan(
+        parameter_lists={
+            Parameter.host: ["runtime.sagemaker.us-west-2.amazonaws.com"],
+            Parameter.region: ["us-west-2"],
+            Parameter.endpoint_name: ["LEARNING-model-simulator-1"],
+            Parameter.endpoint_config_name: ["LEARNING-model-simulator-1-0"],
+            Parameter.variant_name: ["variant-name-1"],
+            Parameter.model_name: ["model-simulator"],
+            Parameter.instance_type: ["ml.m5.large"],
+            Parameter.initial_instance_count: ["10", "11", "12", "13"],
+            Parameter.ramp_start_tps: ["0"],
+            Parameter.ramp_minutes: ["0"],
+            Parameter.steady_state_tps: [f"{peak_tps}"],
+            Parameter.steady_state_minutes: ["30"],
+        },
+        requirements=requirements,
+    )
+    max_count_plan.configs = {}
+    max_count_plan.history = []
+
+    # Max count config 1 (omitting other combos to 4)
+    config = Config(
+        parameters={
+            "host": "runtime.sagemaker.us-west-2.amazonaws.com",
+            "region": "us-west-2",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
+            "variant_name": "variant-name-1",
+            "model_name": "model-simulator",
+            "instance_type": "ml.m5.large",
+            "initial_instance_count": "10",
+            "ramp_start_tps": "0",
+            "ramp_minutes": "0",
+            "steady_state_tps": "1000",
+            "steady_state_minutes": "30",
+        },
+        requirements=requirements,
+    )
+    config.runs = [
+        Run(
+            id="1651395951-ml.m5.large-10-1000TPS",
+            start=datetime.strptime("2022-05-01 09:05:51", "%Y-%m-%d %H:%M:%S"),
+            end=datetime.strptime("2022-05-01 09:35:51", "%Y-%m-%d %H:%M:%S"),
+            results=[
+                Result(
+                    metric=Metric.count_success, value=Decimal(1800000), conditions=[]
+                ),
+                Result(metric=Metric.count_fail, value=Decimal(0), conditions=[]),
+                Result(
+                    metric=Metric.count_total, value=Decimal(1800000), conditions=[]
+                ),
+                Result(
+                    metric=Metric.percent_success, value=Decimal(100), conditions=[]
+                ),
+                Result(
+                    metric=Metric.percent_fail,
+                    value=Decimal(0),
+                    conditions=percent_fail_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_min,
+                    value=Decimal(7),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p25,
+                    value=Decimal(9),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p50,
+                    value=Decimal(10),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p75,
+                    value=Decimal(12),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p90,
+                    value=Decimal(13),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p95,
+                    value=Decimal(16),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p98,
+                    value=Decimal(22),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p99,
+                    value=Decimal(31),
+                    conditions=latency_success_p99_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_max,
+                    value=Decimal(1884),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_start,
+                    value=Decimal(1651395951000),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_end,
+                    value=Decimal(1651397751000),
+                    conditions=[],
+                ),
+            ],
         )
-        config.runs = []
-        max_count_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
-                "ml.m5.large",
-                "4",
-                "0",
-                "0",
-                "10",
-                "30",
-            )
-        ] = config
-
-        # Max count config 4 of 4
-        config = Config(
-            parameters={
-                "host": "runtime.sagemaker.us-west-2.amazonaws.com",
-                "region": "us-west-2",
-                "endpoint_name": "LEARNING-model-sim-public-1",
-                "endpoint_config_name": "LEARNING-model-sim-public-1-0",
-                "variant_name": "variant-name-1",
-                "model_name": "model-sim-public",
-                "instance_type": "ml.m5.large",
-                "initial_instance_count": "5",
-                "ramp_start_tps": "0",
-                "ramp_minutes": "0",
-                "steady_state_tps": "10",
-                "steady_state_minutes": "30",
-            },
-            requirements=requirements,
+    ]
+    max_count_plan.configs[
+        (
+            "runtime.sagemaker.us-west-2.amazonaws.com",
+            "us-west-2",
+            "LEARNING-model-simulator-1",
+            "LEARNING-model-simulator-1-0",
+            "variant-name-1",
+            "model-simulator",
+            "ml.m5.large",
+            "10",
+            "0",
+            "0",
+            "1000",
+            "30",
         )
-        config.runs = []
-        max_count_plan.configs[
-            (
-                "runtime.sagemaker.us-west-2.amazonaws.com",
-                "us-west-2",
-                "LEARNING-model-sim-public-1",
-                "LEARNING-model-sim-public-1-0",
-                "variant-name-1",
-                "model-sim-public",
-                "ml.m5.large",
-                "5",
-                "0",
-                "0",
-                "10",
-                "30",
-            )
-        ] = config
+    ] = config
+    max_count_plan.history.append(config)
 
-        endurance_steady_state_minutes = 30
-        max_instance_count = 2
-        max_steady_state_tps = Decimal(10)
-        max_tps_per_instance = max_steady_state_tps / max_instance_count
-        invocations_target = int(
-            peak_tps / max_instance_count * 60 * SageMaker.SAFETY_FACTOR
+    # Omitting max config 2 through 4 for brevity (all were not run):
+    # ml.m5.large, 11 instances, 1000 TPS
+    # ml.m5.large, 12 instances, 1000 TPS
+    # ml.m5.large, 13 instances, 1000 TPS
+    return max_count_plan
+
+
+@pytest.fixture
+def max_instance_count() -> int:
+    return 10
+
+
+@pytest.fixture
+def invocations_target(peak_tps: Decimal, max_instance_count: int) -> int:
+    return int(peak_tps / max_instance_count * 60 * SageMaker.SAFETY_FACTOR)
+
+
+@pytest.fixture
+def recommend_max(
+    peak_tps: Decimal,
+    max_instance_count: int,
+    instance_type: str,
+    invocations_target: int,
+    cost: CostEstimator,
+) -> Dict[str, str]:
+    recommend_max: Dict[str, str] = {}
+
+    max_steady_state_tps = peak_tps
+    max_tps_per_instance = max_steady_state_tps / max_instance_count
+
+    recommend_max["max_instance_count"] = f"{max_instance_count}"
+    recommend_max["max_steady_state_tps"] = f"{max_steady_state_tps}"
+    recommend_max["max_tps_per_instance"] = f"{max_tps_per_instance}"
+    recommend_max["max_cost"] = cost.explain(instance_type, max_instance_count)
+    recommend_max["invocations_target"] = f"{invocations_target}"
+    recommend_max["explanation"] = (
+        f"Last green run was {max_steady_state_tps} TPS supported by {max_instance_count} instances of {instance_type}.\n"
+        f"max_tps_per_instance = {max_steady_state_tps} / {max_instance_count} = {max_tps_per_instance} TPS per instance.\n"
+        f"Autoscaling metric (SageMakerVariantInvocationsPerInstance):\n"
+        f"= int(max_tps_per_instance * 60 seconds/minute * safety_factor)\n"
+        f"= int({max_tps_per_instance} * 60 * {SageMaker.SAFETY_FACTOR})\n"
+        f"= {invocations_target} invocations / instance / minute"
+    )
+    return recommend_max
+
+
+@pytest.fixture
+def min_count_plan(
+    max_instance_count: int,
+    invocations_target: int,
+    peak_tps: Decimal,
+    requirements: Dict[str, List[Condition]],
+    percent_fail_requirements: List[Condition],
+    latency_success_p99_requirements: List[Condition],
+) -> Plan:
+    # Next is test plan to find min instance count needed for autoscaling.
+    min_count_plan = Plan(
+        parameter_lists={
+            Parameter.host: ["runtime.sagemaker.us-west-2.amazonaws.com"],
+            Parameter.region: ["us-west-2"],
+            Parameter.endpoint_name: ["LEARNING-model-simulator-1"],
+            Parameter.endpoint_config_name: ["LEARNING-model-simulator-1-0"],
+            Parameter.variant_name: ["variant-name-1"],
+            Parameter.model_name: ["model-simulator"],
+            Parameter.instance_type: ["ml.m5.large"],
+            # omitting Parameter.initial_instance_count
+            Parameter.scaling_enabled: ["True"],
+            Parameter.scaling_min_instance_count: list(
+                map(
+                    str,
+                    range(1, max_instance_count + 1),
+                )
+            ),
+            Parameter.scaling_max_instance_count: [str(max_instance_count)],
+            Parameter.scaling_metric: ["SageMakerVariantInvocationsPerInstance"],
+            Parameter.scaling_target: [str(invocations_target)],
+            Parameter.ramp_start_tps: ["0"],
+            Parameter.ramp_minutes: ["15"],
+            Parameter.steady_state_tps: [f"{peak_tps}"],
+            Parameter.steady_state_minutes: ["30"],
+        },
+        requirements=requirements,
+    )
+    min_count_plan.configs = {}
+    min_count_plan.history = []
+
+    # Min count config 1 - try min5 max10 - failed
+    config = Config(
+        parameters={
+            "host": "runtime.sagemaker.us-west-2.amazonaws.com",
+            "region": "us-west-2",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
+            "variant_name": "variant-name-1",
+            "model_name": "model-simulator",
+            "instance_type": "ml.m5.large",
+            # omitting "initial_instance_count"
+            "scaling_enabled": "True",
+            "scaling_min_instance_count": "5",
+            "scaling_max_instance_count": "10",
+            "scaling_metric": "SageMakerVariantInvocationsPerInstance",
+            "scaling_target": "3000",
+            "ramp_start_tps": "0",
+            "ramp_minutes": "15",
+            "steady_state_tps": "1000",
+            "steady_state_minutes": "30",
+        },
+        requirements=requirements,
+    )
+    config.runs = [
+        Run(
+            id="1651399200-ml.m5.large-min5-max10-1000TPS",
+            start=datetime.strptime("2022-05-01 10:00:00", "%Y-%m-%d %H:%M:%S"),
+            end=datetime.strptime("2022-05-01 10:45:00", "%Y-%m-%d %H:%M:%S"),
+            results=[
+                Result(
+                    metric=Metric.count_success, value=Decimal(2248102), conditions=[]
+                ),
+                Result(metric=Metric.count_fail, value=Decimal(1898), conditions=[]),
+                Result(
+                    metric=Metric.count_total, value=Decimal(2250000), conditions=[]
+                ),
+                Result(
+                    metric=Metric.percent_success,
+                    value=Decimal("99.915644444444444"),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.percent_fail,
+                    value=Decimal("0.084355555555556"),
+                    conditions=percent_fail_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_min,
+                    value=Decimal(6),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p25,
+                    value=Decimal(9),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p50,
+                    value=Decimal(11),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p75,
+                    value=Decimal(12),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p90,
+                    value=Decimal(13),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p95,
+                    value=Decimal(19),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p98,
+                    value=Decimal(22),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p99,
+                    value=Decimal(143),
+                    conditions=latency_success_p99_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_max,
+                    value=Decimal(1495),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_start,
+                    value=Decimal(1651399200000),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_end,
+                    value=Decimal(1651401900000),
+                    conditions=[],
+                ),
+            ],
         )
-        recommend_max["max_instance_count"] = f"{max_instance_count}"
-        recommend_max["max_steady_state_tps"] = f"{max_steady_state_tps}"
-        recommend_max["max_tps_per_instance"] = f"{max_tps_per_instance}"
-        recommend_max["max_cost"] = cost.explain(instance_type, max_instance_count)
-        recommend_max["invocations_target"] = f"{invocations_target}"
-        recommend_max["explanation"] = (
-            f"Last green run was {max_steady_state_tps} TPS supported by {max_instance_count} instances of {instance_type}.\n"
-            f"max_tps_per_instance = {max_steady_state_tps} / {max_instance_count} = {max_tps_per_instance} TPS per instance.\n"
-            f"Autoscaling metric (SageMakerVariantInvocationsPerInstance):\n"
-            f"= int(max_tps_per_instance * 60 seconds/minute * safety_factor)\n"
-            f"= int({max_tps_per_instance} * 60 * {SageMaker.SAFETY_FACTOR})\n"
-            f"= {invocations_target} invocations / instance / minute"
+    ]
+    min_count_plan.configs[
+        (
+            "runtime.sagemaker.us-west-2.amazonaws.com",
+            "us-west-2",
+            "LEARNING-model-simulator-1",
+            "LEARNING-model-simulator-1-0",
+            "variant-name-1",
+            "model-simulator",
+            "ml.m5.large",
+            # omitting "initial_instance_count"
+            "True",
+            "5",
+            "10",
+            "SageMakerVariantInvocationsPerInstance",
+            "3000",
+            "0",
+            "15",
+            "1000",
+            "30",
         )
+    ] = config
+    min_count_plan.history.append(config)
 
-        # Next is test plan to find min instance count needed for autoscaling.
+    # Min count config 2 - try min7 max10 - passed
+    config = Config(
+        parameters={
+            "host": "runtime.sagemaker.us-west-2.amazonaws.com",
+            "region": "us-west-2",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
+            "variant_name": "variant-name-1",
+            "model_name": "model-simulator",
+            "instance_type": "ml.m5.large",
+            # omitting "initial_instance_count"
+            "scaling_enabled": "True",
+            "scaling_min_instance_count": "7",
+            "scaling_max_instance_count": "10",
+            "scaling_metric": "SageMakerVariantInvocationsPerInstance",
+            "scaling_target": "3000",
+            "ramp_start_tps": "0",
+            "ramp_minutes": "15",
+            "steady_state_tps": "1000",
+            "steady_state_minutes": "30",
+        },
+        requirements=requirements,
+    )
+    config.runs = [
+        Run(
+            id="1651402800-ml.m5.large-min7-max10-1000TPS",
+            start=datetime.strptime("2022-05-01 11:00:00", "%Y-%m-%d %H:%M:%S"),
+            end=datetime.strptime("2022-05-01 11:45:00", "%Y-%m-%d %H:%M:%S"),
+            results=[
+                Result(
+                    metric=Metric.count_success, value=Decimal(2249880), conditions=[]
+                ),
+                Result(metric=Metric.count_fail, value=Decimal(120), conditions=[]),
+                Result(
+                    metric=Metric.count_total, value=Decimal(2250000), conditions=[]
+                ),
+                Result(
+                    metric=Metric.percent_success,
+                    value=Decimal("99.994666666666667"),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.percent_fail,
+                    value=Decimal("0.005333333333333"),
+                    conditions=percent_fail_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_min,
+                    value=Decimal(7),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p25,
+                    value=Decimal(9),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p50,
+                    value=Decimal(11),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p75,
+                    value=Decimal(12),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p90,
+                    value=Decimal(13),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p95,
+                    value=Decimal(16),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p98,
+                    value=Decimal(22),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p99,
+                    value=Decimal(36),
+                    conditions=latency_success_p99_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_max,
+                    value=Decimal(1521),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_start,
+                    value=Decimal(1651402800000),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_end,
+                    value=Decimal(1651405500000),
+                    conditions=[],
+                ),
+            ],
+        )
+    ]
+    min_count_plan.configs[
+        (
+            "runtime.sagemaker.us-west-2.amazonaws.com",
+            "us-west-2",
+            "LEARNING-model-simulator-1",
+            "LEARNING-model-simulator-1-0",
+            "variant-name-1",
+            "model-simulator",
+            "ml.m5.large",
+            # omitting "initial_instance_count"
+            "True",
+            "7",
+            "10",
+            "SageMakerVariantInvocationsPerInstance",
+            "3000",
+            "0",
+            "15",
+            "1000",
+            "30",
+        )
+    ] = config
+    min_count_plan.history.append(config)
 
-        # TODO: Implement testing process to determine min count for autoscaling...
-        # min_count_plan = None
-        # min_count_workflow = None
-        # min_count_recommendation = None
+    # Min count config 3 - try min6 max10 - failed
+    config = Config(
+        parameters={
+            "host": "runtime.sagemaker.us-west-2.amazonaws.com",
+            "region": "us-west-2",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
+            "variant_name": "variant-name-1",
+            "model_name": "model-simulator",
+            "instance_type": "ml.m5.large",
+            # omitting "initial_instance_count"
+            "scaling_enabled": "True",
+            "scaling_min_instance_count": "6",
+            "scaling_max_instance_count": "10",
+            "scaling_metric": "SageMakerVariantInvocationsPerInstance",
+            "scaling_target": "3000",
+            "ramp_start_tps": "0",
+            "ramp_minutes": "15",
+            "steady_state_tps": "1000",
+            "steady_state_minutes": "30",
+        },
+        requirements=requirements,
+    )
+    config.runs = [
+        Run(
+            id="1651406400-ml.m5.large-min6-max10-1000TPS",
+            start=datetime.strptime("2022-05-01 12:00:00", "%Y-%m-%d %H:%M:%S"),
+            end=datetime.strptime("2022-05-01 12:45:00", "%Y-%m-%d %H:%M:%S"),
+            results=[
+                Result(
+                    metric=Metric.count_success, value=Decimal(2249407), conditions=[]
+                ),
+                Result(metric=Metric.count_fail, value=Decimal(593), conditions=[]),
+                Result(
+                    metric=Metric.count_total, value=Decimal(2250000), conditions=[]
+                ),
+                Result(
+                    metric=Metric.percent_success,
+                    value=Decimal("99.973644444444444"),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.percent_fail,
+                    value=Decimal("0.026355555555556"),
+                    conditions=percent_fail_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_min,
+                    value=Decimal(6),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p25,
+                    value=Decimal(9),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p50,
+                    value=Decimal(11),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p75,
+                    value=Decimal(12),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p90,
+                    value=Decimal(13),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p95,
+                    value=Decimal(18),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p98,
+                    value=Decimal(22),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.latency_success_p99,
+                    value=Decimal(65),
+                    conditions=latency_success_p99_requirements,
+                ),
+                Result(
+                    metric=Metric.latency_success_max,
+                    value=Decimal(1701),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_start,
+                    value=Decimal(1651406400000),
+                    conditions=[],
+                ),
+                Result(
+                    metric=Metric.simulation_end,
+                    value=Decimal(1651409100000),
+                    conditions=[],
+                ),
+            ],
+        )
+    ]
+    min_count_plan.configs[
+        (
+            "runtime.sagemaker.us-west-2.amazonaws.com",
+            "us-west-2",
+            "LEARNING-model-simulator-1",
+            "LEARNING-model-simulator-1-0",
+            "variant-name-1",
+            "model-simulator",
+            "ml.m5.large",
+            # omitting "initial_instance_count"
+            "True",
+            "6",
+            "10",
+            "SageMakerVariantInvocationsPerInstance",
+            "3000",
+            "0",
+            "15",
+            "1000",
+            "30",
+        )
+    ] = config
+    min_count_plan.history.append(config)
+    return min_count_plan
 
-        recommend_min["min_instance_count"] = "-"  # TODO: implement
-        recommend_min["min_cost"] = "-"  # TODO: implement
 
+@pytest.fixture
+def recommend_min(
+    invocations_target: int,
+    cost: CostEstimator,
+    instance_type: str,
+    max_instance_count: int,
+) -> Dict[str, str]:
+    recommend_min: Dict[str, str] = {}
+    min_instance_count = 7
+    scaling_metric = "SageMakerVariantInvocationsPerInstance"
+    scaling_target = f"{invocations_target}"
+    ramp_start_tps = "0"
+    ramp_minutes = "15"
+    steady_state_tps = "1000"
+    steady_state_minutes = "30"
+    recommend_min["min_instance_count"] = str(min_instance_count)
+    recommend_min["min_cost"] = cost.explain(instance_type, min_instance_count)
+    recommend_min["explanation"] = (
+        f"Traffic was {ramp_start_tps} TPS ramped over {ramp_minutes} minutes to {steady_state_tps} TPS, and then run for {steady_state_minutes} minutes.\n"
+        f"Last green run was auto scale configuration with minimum {min_instance_count}, maximum {max_instance_count} instances of type {instance_type},\n"
+        f"with scaling metric {scaling_metric} at {scaling_target} as calculated earlier.\n"
+    )
+    return recommend_min
+
+
+class TestHTMLReporter:
+    def test_render_all_tests_pass(
+        self,
+        inputs: Dict[str, str],
+        type_plan: Plan,
+        max_count_plan: Plan,
+        min_count_plan: Plan,
+        recommend_type: Dict[str, str],
+        recommend_max: Dict[str, str],
+        recommend_min: Dict[str, str],
+    ) -> None:
+        reporter = HTMLReporter(
+            inputs=inputs,
+            type_plan=type_plan,
+            max_count_plan=max_count_plan,
+            min_count_plan=min_count_plan,
+            recommend_type=recommend_type,
+            recommend_max=recommend_max,
+            recommend_min=recommend_min,
+        )
+        content = reporter.render()
+        # Uncomment for debugging...
+        # with open(f"Final_Job_Report.html", "w") as file:
+        #     file.write(content)
+        summary = (
+            "Success! Based on the provided inputs, here are the "
+            "suggested settings for deploying model-simulator with either "
+            "fixed scale or auto scale."
+        )
+        assert summary in content
+
+    def test_render_auto_scale_failed(
+        self,
+        inputs: Dict[str, str],
+        type_plan: Plan,
+        max_count_plan: Plan,
+        min_count_plan: Plan,
+        recommend_type: Dict[str, str],
+        recommend_max: Dict[str, str],
+        recommend_min: Dict[str, str],
+    ) -> None:
+        reporter = HTMLReporter(
+            inputs=inputs,
+            type_plan=type_plan,
+            max_count_plan=max_count_plan,
+            min_count_plan=min_count_plan,
+            recommend_type=recommend_type,
+            recommend_max=recommend_max,
+            recommend_min=None,
+        )
+        content = reporter.render()
+        # Uncomment for debugging...
+        # with open(f"Final_Job_Report.html", "w") as file:
+        #    file.write(content)
+        summary = (
+            "Success! Based on the provided inputs, here are the "
+            "suggested settings for deploying model-simulator with fixed "
+            "scale. But for auto scale, the tests were either skipped "
+            "or failed."
+        )
+        assert summary in content
+        # No final auto scale recommendation, but tests were still attempted.
+        # Ignore placeholder values from test fixture data though, since those
+        # were populated for the successful case.
+        text = (
+            "Instance Type and Auto Scale (left column) vs. Traffic Pattern (top row):"
+        )
+        assert text in content
+        text = "ERROR: Endurance tests using given ramp traffic pattern failed to meet SLA rules."
+        assert text in content
+
+    def test_render_auto_scale_skipped(
+        self,
+        inputs: Dict[str, str],
+        type_plan: Plan,
+        max_count_plan: Plan,
+        min_count_plan: Plan,
+        recommend_type: Dict[str, str],
+        recommend_max: Dict[str, str],
+        recommend_min: Dict[str, str],
+    ) -> None:
         reporter = HTMLReporter(
             inputs=inputs,
             type_plan=type_plan,
@@ -863,11 +1386,111 @@ class TestHTMLReporter:
             min_count_plan=None,
             recommend_type=recommend_type,
             recommend_max=recommend_max,
-            recommend_min=recommend_min,
+            recommend_min=None,
         )
         content = reporter.render()
-        success = "Success! Based on the provided inputs, here are the suggested settings for deploying model-sim-public."
-        assert success in content
-
+        # Uncomment for debugging...
         # with open(f"Final_Job_Report.html", "w") as file:
         #     file.write(content)
+        summary = (
+            "Success! Based on the provided inputs, here are the "
+            "suggested settings for deploying model-simulator with fixed "
+            "scale. But for auto scale, the tests were either skipped "
+            "or failed."
+        )
+        assert summary in content
+        # In this case, the auto scale testing section was skipped altogether.
+        text = (
+            "This section was skipped either by configuration, or due to above errors."
+        )
+        assert text in content
+
+    def test_render_endurance_failed(
+        self,
+        inputs: Dict[str, str],
+        type_plan: Plan,
+        max_count_plan: Plan,
+        min_count_plan: Plan,
+        recommend_type: Dict[str, str],
+        recommend_max: Dict[str, str],
+        recommend_min: Dict[str, str],
+    ) -> None:
+        reporter = HTMLReporter(
+            inputs=inputs,
+            type_plan=type_plan,
+            max_count_plan=max_count_plan,
+            min_count_plan=None,
+            recommend_type=recommend_type,
+            recommend_max=None,
+            recommend_min=None,
+        )
+        content = reporter.render()
+        # Uncomment for debugging...
+        # with open(f"Final_Job_Report.html", "w") as file:
+        #     file.write(content)
+        summary = (
+            "Failure! Found instance type ml.m5.large worked for type tests, "
+            "but endurance tests failed."
+        )
+        assert summary in content
+        text = "ERROR: Endurance tests failed to meet SLA rules."
+        assert text in content
+
+    def test_render_endurance_skipped(
+        self,
+        inputs: Dict[str, str],
+        type_plan: Plan,
+        max_count_plan: Plan,
+        min_count_plan: Plan,
+        recommend_type: Dict[str, str],
+        recommend_max: Dict[str, str],
+        recommend_min: Dict[str, str],
+    ) -> None:
+        reporter = HTMLReporter(
+            inputs=inputs,
+            type_plan=type_plan,
+            max_count_plan=None,
+            min_count_plan=None,
+            recommend_type=recommend_type,
+            recommend_max=None,
+            recommend_min=None,
+        )
+        content = reporter.render()
+        # Uncomment for debugging...
+        # with open(f"Final_Job_Report.html", "w") as file:
+        #     file.write(content)
+        summary = (
+            "Failure! Found instance type ml.m5.large worked for type tests, "
+            "but endurance tests failed."
+        )
+        assert summary in content
+        text = (
+            "This section was skipped either by configuration, or due to above errors."
+        )
+        assert text in content
+
+    def test_render_type_failed(
+        self,
+        inputs: Dict[str, str],
+        type_plan: Plan,
+        max_count_plan: Plan,
+        min_count_plan: Plan,
+        recommend_type: Dict[str, str],
+        recommend_max: Dict[str, str],
+        recommend_min: Dict[str, str],
+    ) -> None:
+        reporter = HTMLReporter(
+            inputs=inputs,
+            type_plan=type_plan,
+            max_count_plan=None,
+            min_count_plan=None,
+            recommend_type=None,
+            recommend_max=None,
+            recommend_min=None,
+        )
+        content = reporter.render()
+        # Uncomment for debugging...
+        # with open(f"Final_Job_Report.html", "w") as file:
+        #     file.write(content)
+        summary = "Failure! No solution found given inputs below."
+        assert summary in content

--- a/tests/step/test_sagemaker.py
+++ b/tests/step/test_sagemaker.py
@@ -11,7 +11,10 @@ from perfsize.load.mock import MockLoadManager
 from perfsize.reporter.mock import MockReporter
 from perfsize.result.mock import MockResultManager
 from perfsizesagemaker.constants import Parameter
-from perfsizesagemaker.step.sagemaker import FirstSuccessStepManager
+from perfsizesagemaker.step.sagemaker import (
+    FirstSuccessStepManager,
+    AutoScaleMinFinderStepManager,
+)
 import pytest
 
 
@@ -84,6 +87,7 @@ class TestFirstSuccessStepManager:
             reporters=[MockReporter()],
         )
         recommendation = workflow.run()
+        # Mock run will go through first instance type and all TPS steps
         assert len(sample_plan.history) == 22
         assert recommendation == {
             "host": "runtime.sagemaker.us-west-2.amazonaws.com",
@@ -98,4 +102,72 @@ class TestFirstSuccessStepManager:
             "ramp_minutes": "0",
             "steady_state_tps": "400",
             "steady_state_minutes": "3",
+        }
+
+
+@pytest.fixture
+def auto_scale_plan() -> Plan:
+    return Plan(
+        parameter_lists={
+            Parameter.host: ["runtime.sagemaker.us-west-2.amazonaws.com"],
+            Parameter.region: ["us-west-2"],
+            Parameter.endpoint_name: ["LEARNING-model-simulator-1"],
+            Parameter.endpoint_config_name: ["LEARNING-model-simulator-1-0"],
+            Parameter.variant_name: ["variant-name-1"],
+            Parameter.model_name: ["model-simulator"],
+            Parameter.instance_type: ["ml.m5.large"],
+            # omitting Parameter.initial_instance_count
+            Parameter.scaling_enabled: ["True"],
+            Parameter.scaling_min_instance_count: ["1", "2", "3", "4", "5"],
+            Parameter.scaling_max_instance_count: ["5"],
+            Parameter.scaling_metric: ["SageMakerVariantInvocationsPerInstance"],
+            Parameter.scaling_target: ["100"],
+            Parameter.ramp_start_tps: ["0"],
+            Parameter.ramp_minutes: ["15"],
+            Parameter.steady_state_tps: ["400"],
+            Parameter.steady_state_minutes: ["30"],
+        },
+        requirements={
+            "latency_success_p99": [
+                Condition(lt(Decimal("200")), "value < 200"),
+                Condition(gte(Decimal("0")), "value >= 0"),
+            ],
+            "percent_fail": [
+                Condition(lt(Decimal("0.01")), "value < 0.01"),
+                Condition(gte(Decimal("0")), "value >= 0"),
+            ],
+        },
+    )
+
+
+class TestAutoScaleMinFinderStepManager:
+    def test_plan(self, auto_scale_plan: Plan) -> None:
+        workflow = Workflow(
+            plan=auto_scale_plan,
+            step_manager=AutoScaleMinFinderStepManager(auto_scale_plan),
+            environment_manager=MockEnvironmentManager(),
+            load_manager=MockLoadManager(),
+            result_managers=[MockResultManager()],
+            reporters=[MockReporter()],
+        )
+        recommendation = workflow.run()
+        # Mock run for max 5 instances will try min=5/2=2, then min=2/1=1.
+        assert len(auto_scale_plan.history) == 2
+        assert recommendation == {
+            "host": "runtime.sagemaker.us-west-2.amazonaws.com",
+            "region": "us-west-2",
+            "endpoint_name": "LEARNING-model-simulator-1",
+            "endpoint_config_name": "LEARNING-model-simulator-1-0",
+            "variant_name": "variant-name-1",
+            "model_name": "model-simulator",
+            "instance_type": "ml.m5.large",
+            "scaling_enabled": "True",
+            "scaling_min_instance_count": "1",
+            "scaling_max_instance_count": "5",
+            "scaling_metric": "SageMakerVariantInvocationsPerInstance",
+            "scaling_target": "100",
+            "ramp_start_tps": "0",
+            "ramp_minutes": "15",
+            "steady_state_tps": "400",
+            "steady_state_minutes": "30",
         }


### PR DESCRIPTION
## Summary

* What changed, and why? Tool can now configure and test auto scale settings, in order to see if an Auto Scale configuration can support the given user requirements.
* Any related GitHub Issue links? No
* Anything that impacts backward compatibility? No


## Testing

* How has this change been tested? Added unit tests, also tested end-to-end using Jenkins. 
* Any setup needed for running the tests? For unit tests, `make test` covers running the new tests. For end-to-end testing, see Jenkins setup at https://github.com/intuit/perfsizesagemaker/blob/main/JenkinsfilePerfTest


## Sample Report

Ran perfsizesagemaker on model-simulator with the inputs below and got a successful recommendation including auto scale.

![image](https://user-images.githubusercontent.com/18709381/176135499-cc6461a4-7417-4f42-8a83-de4e13a14343.png)


## Checklist

* [x] Add tests
* [x] Add docs
* [x] Follow coding standards and styles of the project
* [x] Changes are not generating new errors or warnings
